### PR TITLE
Fix issue with disappearing about me section

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -57,7 +57,7 @@ const IndexPage = ({ data }) => {
           </h3>
           <p
             className="description-text text-justify"
-            dangerouslySetInnerHTML={{ __html: node.node.html }}
+            dangerouslySetInnerHTML={{ __html: node.node.internal.content }}
           />
         </div>
       ))}
@@ -84,11 +84,10 @@ export const pageData = graphql`
         node {
           frontmatter {
             title
-            featuredImage {
-              publicURL
-            }
           }
-          html
+          internal {
+            content
+          }
         }
       }
     }


### PR DESCRIPTION
The main text of the about me section kept disappearing shortly loading
the index page. For now, this can be fixed by using the internal content
of these markdown files instead of the generated HTML. Since the content
is a single paragraph this does not make a difference for constructing
the page.